### PR TITLE
Fix ruby version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-ruby@v1
       with:
-        ruby-version: '2.6.5'
+        ruby-version: '2.6.x'
     - run: |
         sudo apt-get install libsqlite3-dev
         gem install bundler

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       with:
         ruby-version: '2.6.x'
     - run: |
-        sudo apt-get install libsqlite3-dev
+        sudo apt-get install sqlite3 libsqlite3-dev
         gem install bundler
         bundle install --jobs 4 --retry 3
         bundle exec rspec


### PR DESCRIPTION
### Purpose
Unpin ruby version

### Context
CI is broken because the ruby version is pinned to a specific ruby 2.6 version that is unavailable.